### PR TITLE
6.7.x

### DIFF
--- a/Configuration/PageTSconfig/Suggest.tsconfig
+++ b/Configuration/PageTSconfig/Suggest.tsconfig
@@ -1,7 +1,7 @@
 # ***************************************************************************************
 # Translate currency labels in suggestions
 # ***************************************************************************************
-[language = *ru*]
+[siteLanguage("twoLetterIsoCode") == "ru"]
 	TCEFORM.sys_language.static_lang_isocode.suggest.default.additionalSearchFields = lg_name_ru
 	TCEFORM.sys_language.static_lang_isocode.suggest.default.orderBy = lg_name_ru
 	TCEFORM.static_countries.cn_currency_uid.suggest.default.additionalSearchFields = cu_name_ru

--- a/Configuration/PageTSconfig/Suggest_9.tsconfig
+++ b/Configuration/PageTSconfig/Suggest_9.tsconfig
@@ -1,7 +1,7 @@
 # ***************************************************************************************
 # Translate currency labels in suggestions
 # ***************************************************************************************
-[language = *ru*]
+[siteLanguage("twoLetterIsoCode") == "ru"]
 	TCEFORM.sys_language.static_lang_isocode.suggest.default.additionalSearchFields = lg_name_ru
 	TCEFORM.sys_language.static_lang_isocode.suggest.default.orderBy = lg_name_ru
 	TCEFORM.static_countries.cn_currency_uid.suggest.default.additionalSearchFields = cu_name_ru

--- a/Configuration/PageTSconfig/Suggest_prior_9.tsconfig
+++ b/Configuration/PageTSconfig/Suggest_prior_9.tsconfig
@@ -1,7 +1,7 @@
 # ***************************************************************************************
 # Translate currency labels in suggestions
 # ***************************************************************************************
-[siteLanguage("twoLetterIsoCode") == "ru"]
+[language = *ru*]
 	TCEFORM.sys_language.static_lang_isocode.suggest.default.additionalSearchFields = lg_name_ru
 	TCEFORM.sys_language.static_lang_isocode.suggest.default.orderBy = lg_name_ru
 	TCEFORM.static_countries.cn_currency_uid.suggest.default.additionalSearchFields = cu_name_ru

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -5,7 +5,7 @@ $EM_CONF[$_EXTKEY] = [
     'description' => '(ru) language pack for the Static Info Tables providing localized names for countries, 
                        currencies and so on.',
     'category' => 'misc',
-    'version' => '6.7.0',
+    'version' => '6.7.1',
     'dependencies' => '',
     'state' => 'stable',
     'uploadfolder' => true,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,12 +2,19 @@
 defined('TYPO3_MODE') or die();
 
 $initialize = function ($extKey) {
+    $isVersion9Up = \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 9000000;
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
         '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/TypoScript/Extbase/setup.txt">'
     );
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
-    );
+    if ($isVersion9Up) {
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest_9.tsconfig">'
+        );
+    } else {
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
+        );
+    }
 };
 $initialize(\Mselbach\StaticInfoTablesRu\Extension::EXTENSION_KEY);
 unset($initialize);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,11 +8,11 @@ $initialize = function ($extKey) {
     );
     if ($isVersion9Up) {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest_9.tsconfig">'
+            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
         );
     } else {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
+            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest_prior_9.tsconfig">'
         );
     }
 };

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,7 +6,7 @@ $initialize = function ($extKey) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
         '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/TypoScript/Extbase/setup.txt">'
     );
-    if ($isVersion9Up) {
+    if (version_compare(TYPO3_branch, '9.5', '>=')) {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
             '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
         );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,7 +2,6 @@
 defined('TYPO3_MODE') or die();
 
 $initialize = function ($extKey) {
-    $isVersion9Up = \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 9000000;
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
         '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/TypoScript/Extbase/setup.txt">'
     );


### PR DESCRIPTION
fixes #6, removed deprecated TypoScript for TYPO3 9.5