### PR TITLE
Feature/add compatibility to 11.5

### DIFF
--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
+        php: [ '7.4' ]
     name: PHPstan
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-composer-
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.4
           coverage: none
       - run: composer install --no-progress
       - run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
-        typo3: [ '^9.5', '^10.4', 'dev-master' ]
+        php: [ '7.4' ]
+        typo3: [ '^11.5', 'dev-master' ]
 
     name: PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }} tests
     steps:

--- a/Configuration/PageTSconfig/Suggest_prior_9.tsconfig
+++ b/Configuration/PageTSconfig/Suggest_prior_9.tsconfig
@@ -1,9 +1,0 @@
-# ***************************************************************************************
-# Translate currency labels in suggestions
-# ***************************************************************************************
-[language = *ru*]
-	TCEFORM.sys_language.static_lang_isocode.suggest.default.additionalSearchFields = lg_name_ru
-	TCEFORM.sys_language.static_lang_isocode.suggest.default.orderBy = lg_name_ru
-	TCEFORM.static_countries.cn_currency_uid.suggest.default.additionalSearchFields = cu_name_ru
-	TCEFORM.static_countries.cn_currency_uid.suggest.default.orderBy = cu_name_ru
-[global]

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
     "mselbach/static-info-tables-ru": "self.version"
   },
   "require": {
-    "php": ">=7.2",
-    "typo3/cms-core": "^9.5 || ^10.4 || ^11.0 || dev-master",
-    "sjbr/static-info-tables": "^6.9"
+    "php": ">=7.4",
+    "typo3/cms-core": "^11.5 || dev-master",
+    "sjbr/static-info-tables": "^11.5"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",
     "squizlabs/php_codesniffer": "^3.5",
-    "nimut/testing-framework": "2.x-dev || 3.x-dev || 4.x-dev || ^5.0",
+    "nimut/testing-framework": "^6.0",
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan": "^0.12.67",
     "phpstan/phpstan-deprecation-rules": "^0.12.5",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,8 +2,7 @@
 
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Static Info Tables (ru)',
-    'description' => '(ru) language pack for the Static Info Tables providing localized names for countries, 
-                       currencies and so on.',
+    'description' => '(ru) language pack for the Static Info Tables providing localized names for countries, currencies and so on.',
     'category' => 'misc',
     'version' => '6.9.0',
     'state' => 'stable',
@@ -14,9 +13,9 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'manuel_selbach@yahoo.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-10.4.99',
-            'static_info_tables' => '6.9.0-6.9.99',
-            'php' => '7.2.0-0.0.0',
+            'typo3' => '11.5.0-11.5.99',
+            'static_info_tables' => '11.5.0-11.5.99',
+            'php' => '7.4.0-0.0.0',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,19 +1,12 @@
 <?php
 defined('TYPO3_MODE') or die();
 
-$initialize = function ($extKey) {
+(function ($extKey) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
         '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/TypoScript/Extbase/setup.txt">'
     );
-    if (version_compare(TYPO3_branch, '9.5', '>=')) {
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
-        );
-    } else {
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest_prior_9.tsconfig">'
-        );
-    }
-};
-$initialize(\Mselbach\StaticInfoTablesRu\Extension::EXTENSION_KEY);
-unset($initialize);
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
+    );
+})(\Mselbach\StaticInfoTablesRu\Extension::EXTENSION_KEY);


### PR DESCRIPTION
With this changes the compatibility to version 11.5 of extension static_info_tables is achieved.